### PR TITLE
single precision float version

### DIFF
--- a/fftw3f.nim
+++ b/fftw3f.nim
@@ -1,0 +1,326 @@
+### Introduction
+
+## Nim binding for the FFTW3 library
+##
+## FFTW is one the best library to compute Fourier transforms of various kinds with high performance.
+##
+## Make sure FFTW's documentation : http://www.ffwf.org/ffwf3_doc/
+##
+## The C-bindings can be used identically to the C-API
+##
+## In order to simplify usage an Arraymancer high level API is added on top of the low-level API.
+##
+
+### Examples
+
+####  C-Binding low-level example
+runnableExamples:
+  import ffwf3
+  const N = 3
+  var input: array[N, cfloat] = [0.0, 2.0, 6.0]
+  var output: array[N, cfloat]
+  let bufIn = cast[ptr UncheckedArray[cfloat]](addr(input[0]))
+  let bufOut = cast[ptr UncheckedArray[cfloat]](addr(output[0]))
+  let plan = fftwf_plan_r2r_1d(N, bufIn, bufOut, fftwf_r2r_kind.FFTW_REDFT00, FFTW_ESTIMATE)
+  fftwf_execute(plan)
+  let expectedResult: array[N, cfloat] = [10.0, -6.0, 2.0]
+  for i in low(output)..high(output):
+    assert abs(output[i] - expectedResult[i]) < 1.0e-14
+
+####  Arraymancer API example
+runnableExamples:
+  import arraymancer
+  import ffwf3
+  import sequtils
+
+  var
+    input  : Tensor[Complex32] = newTensor[Complex32](@[10, 10, 10])
+    reInput = randomTensor[float32](10, 10, 100.0)
+    imInput = randomTensor[float32](10, 10, 100.0)
+
+  for i, x in input.menumerate:
+    x.re = reInput.atContiguousIndex(i)
+    x.im = imInput.atContiguousIndex(i)
+
+  # Allocate output Tensor
+  var output = newTensor[Complex32](input.shape.toSeq)
+  # Create a plan
+  var plan : fftwf_plan = fftwf_plan_dft(input, output, FFTW_FORWARD, FFTW_ESTIMATE)
+  # Execute plan in-place
+  fftwf_execute(plan)
+
+### Planner flags
+
+## Planner are const integer that specify how the DFT plan should be computed.
+## More information about `planner flags <http://www.ffwf.org/doc/Planner-Flags.html>`_
+
+import arraymancer
+import sequtils
+import complex
+import fftw3f/libutils
+# Import mostly for documentation links
+{.push warning[UnusedImport]: off.}
+import fftw3f/guru, fftw3f/wisdom
+{.pop.}
+import fftw3f/fftshift
+# export used types
+export fftwf_plan
+export fftwf_r2r_kind
+export fftshift
+
+const
+    FFTW_MEASURE* = 0              ## ``fftwf_plan`` planner flag.
+                                   ##
+                      ## Find an optimized plan by computing several FFTs and measuring their execution time. Default planning option.
+    FFTW_ESTIMATE* = 1 shl 6       ## ``fftwf_plan`` planner flag.
+                                   ##
+                             ## Instead of time measurements, a simple heuristic is used to pick a plan quickly. The input/output arrays are not overwritten during planning.
+    FFTW_PATIENT* = 1 shl 5        ## ``fftwf_plan`` planner flag.
+                                   ##
+                                   ## Like FFTW_MEASURE, but considers a wider range of algorithms.
+    FFTW_EXHAUSTIVE* = 1 shl 3     ## ``fftwf_plan`` planner flag.
+                                   ##
+                                   ## Like FFTW_PATIENT, but considers an even wider range of algorithms.
+    FFTW_WISDOM_ONLY* = 1 shl 21   ## ``fftwf_plan`` planner flag.
+                                   ##
+                                   ## Special planning mode in which the plan is created only if wisdow is available.
+
+    FFTW_DESTROY_INPUT* = 1        ## ``fftwf_plan`` planner flag.
+                                   ##
+                            ## An out-of-place transform is allowed to overwrite its input array with arbitrary data. Default value for complex-to-real transform.
+    FFTW_PRESERVE_INPUT* = 1 shl 4 ## ``fftwf_plan`` planner flag.
+                                   ##
+                                   ## An out-of-place transform must not change its input array. Default value except for complex-to-real (c2r and hc2r).
+    FFTW_UNALIGNED* = 1 shl 1      ## ``fftwf_plan`` planner flag.
+                                   ##
+                              ## The algorithm may not impose any unusual alignment requirements on the input/output arrays.(i.e. no SIMD may be used).
+    FFTW_CONSERVE_MEMORY* = 1 shl 2
+
+const
+    FFTW_FORWARD* = -1 ## ``fftwf_plan`` sign flag.
+                       ##
+                       ## Compute a DFT transform.
+    FFTW_BACKWARD* = 1 ## ``fftwf_plan`` sign flag.
+                       ##
+                       ## Compute an inverse DFT transform.
+
+# FFTW Execute API
+proc fftwf_execute*(p: fftwf_plan) {.cdecl, importc: "fftwf_execute", dynlib: Fftw3Lib.}
+  ## Execute a plan
+
+proc fftwf_execute_dft*(p: fftwf_plan, inptr: ptr UncheckedArray[Complex32], outptr: ptr UncheckedArray[Complex32]) {.
+        cdecl, importc: "fftwf_execute_dft", dynlib: Fftw3Lib.}
+  ## Execute a plan with different input / output memory address
+
+proc fftwf_execute_dft*(p: fftwf_plan, input: Tensor[Complex32], output: Tensor[Complex32]) =
+    ## Execute an fft using a pre-calculated ``fftwf_plan``
+    runnableExamples:
+        import arraymancer
+        import ffwf3
+        let shape = @[100, 100]
+        # Create dummy tensors
+        var
+            dummy_input = newTensor[Complex32](shape)
+            dummy_output = newTensor[Complex32](shape)
+        # Use dummy tensor to create plan
+        var plan: fftwf_plan = fftwf_plan_dft(dummy_input, dummy_output, FFTW_FORWARD, FFTW_ESTIMATE)
+        # Allocate output Tensor
+        # It is crucial to NOT modify the dimensions of the tensor
+        var inputRe: Tensor[float32] = randomTensor[float32](shape, 10.0)
+        var inputIm: Tensor[float32] = randomTensor[float32](shape, 20.0)
+        var input = map2_inline(inputRe, inputIm):
+            complex64(x, y)
+        let in_shape = @(input.shape)
+        var output = newTensor[Complex32](in_shape)
+        # Execute plan with output_tensor and input_tensor
+        fftwf_execute_dft(plan, input, output) ## Execute a plan on new Tensor
+
+    fftwf_execute_dft(p, input.toUnsafeView(), output.toUnsafeView())
+
+proc fftwf_execute_r2r*(p: fftwf_plan, inptr: ptr UncheckedArray[cfloat], outptr: ptr UncheckedArray[cfloat]) {.cdecl,
+        importc: "fftwf_execute_r2r", dynlib: Fftw3Lib.}
+  ## Execute a plan real-to-real
+
+proc fftwf_execute_dft_r2c*(p: fftwf_plan, inptr: ptr UncheckedArray[cfloat], outptr: ptr UncheckedArray[Complex32]) {.
+        cdecl, importc: "fftwf_execute_dft_r2c", dynlib: Fftw3Lib.}
+  ## Execute a plan real-to-complex
+
+proc fftwf_execute_dft_r2c*(p: fftwf_plan, input: Tensor[float32], output: Tensor[Complex32]) =
+    ## Execute a real-to-complex plan on new Tensor
+    fftwf_execute_dft_r2c(p, input.asType(cfloat).toUnsafeView(), output.toUnsafeView())
+
+proc fftwf_execute_dft_c2r*(p: fftwf_plan, inptr: ptr UncheckedArray[Complex32], outptr: ptr UncheckedArray[cfloat]) {.
+        cdecl, importc: "fftwf_execute_dft_c2r", dynlib: Fftw3Lib.}
+  ## Execute a plan complex-to-real
+
+proc fftwf_execute_dft_c2r*(p: fftwf_plan, input: Tensor[Complex32], output: Tensor[float32]) =
+    ## Execute a complex-to-real plan on new Tensor
+    fftwf_execute_dft_c2r(p, input.toUnsafeView(), cast[ptr UncheckedArray[cfloat]](output.toUnsafeView()))
+
+# FFTW Plan API
+proc fftwf_plan_dft*(rank: cint, n: ptr cint, inptr: ptr UncheckedArray[Complex32],
+                    outptr: ptr UncheckedArray[Complex32], sign: cint, flags: cuint): fftwf_plan {.
+    cdecl, importc: "fftwf_plan_dft", dynlib: Fftw3Lib.}
+
+proc fftwf_plan_dft_1d*(n: cint, inptr: ptr UncheckedArray[Complex32], outptr: ptr UncheckedArray[Complex32], sign: cint,
+        flags: cuint): fftwf_plan {.cdecl, importc: "fftwf_plan_dft_1d", dynlib: Fftw3Lib.}
+
+proc fftwf_plan_dft_2d*(n0: cint, n1: cint, inptr: ptr UncheckedArray[Complex32], outptr: ptr UncheckedArray[Complex32],
+        sign: cint, flags: cuint): fftwf_plan {.cdecl, importc: "fftwf_plan_dft_2d", dynlib: Fftw3Lib.}
+
+proc fftwf_plan_dft_3d*(n0: cint, n1: cint, n2: cint, inptr: ptr UncheckedArray[Complex32], outptr: ptr UncheckedArray[
+        Complex32], sign: cint, flags: cuint): fftwf_plan {.cdecl, importc: "fftwf_plan_dft_3d", dynlib: Fftw3Lib.}
+
+proc fftwf_plan_dft*(input: Tensor[Complex32], output: Tensor[Complex32], sign: cint,
+        flags: cuint = FFTW_MEASURE): fftwf_plan =
+    ## Generic Tensor plan calculation using FFTW_MEASURE as a default ffwf flag.
+    ##
+    ## Read carefully FFTW documentation about the input / output dimension it will change depending on the transformation.
+    case input.rank:
+    of 1:
+      fftwf_plan_dft_1d(input.shape[0].cint, input.toUnsafeView(), output.toUnsafeView(), sign, flags)
+    of 2:
+      fftwf_plan_dft_2d(input.shape[0].cint, input.shape[1].cint, input.toUnsafeView(), output.toUnsafeView(), sign, flags)
+    of 3:
+      fftwf_plan_dft_3d(input.shape[0].cint, input.shape[1].cint, input.shape[2].cint, input.toUnsafeView(), output.toUnsafeView(), sign, flags)
+    else:
+      var shape: seq[cint] = map(input.shape.toSeq, proc(x: int): cint = x.cint)
+      fftwf_plan_dft(input.rank.cint, (shape[0].unsafeaddr), input.toUnsafeView(), output.toUnsafeView(), sign, flags)
+
+
+proc fftwf_plan_dft_r2c*(rank: cint, n: ptr cint, inptr: ptr UncheckedArray[cfloat], outptr: ptr UncheckedArray[
+        Complex32], flags: cuint): fftwf_plan {.cdecl, importc: "fftwf_plan_dft_r2c", dynlib: Fftw3Lib.}
+
+proc fftwf_plan_dft_r2c_1d*(n: cint, inptr: ptr UncheckedArray[cfloat], outptr: ptr UncheckedArray[Complex32],
+        flags: cuint): fftwf_plan {.cdecl, importc: "fftwf_plan_dft_r2c_1d", dynlib: Fftw3Lib.}
+
+proc fftwf_plan_dft_r2c_2d*(n0: cint, n1: cint, inptr: ptr UncheckedArray[cfloat], outptr: ptr UncheckedArray[
+        Complex32], flags: cuint): fftwf_plan {.
+    cdecl, importc: "fftwf_plan_dft_r2c_2d", dynlib: Fftw3Lib.}
+
+proc fftwf_plan_dft_r2c_3d*(n0: cint, n1: cint, n2: cint, inptr: ptr UncheckedArray[cfloat], outptr: ptr UncheckedArray[
+        Complex32], flags: cuint): fftwf_plan {.cdecl, importc: "fftwf_plan_dft_r2c_3d", dynlib: Fftw3Lib.}
+
+proc fftwf_plan_dft_r2c*(input: Tensor[float32], output: Tensor[Complex32], flags: cuint = FFTW_MEASURE): fftwf_plan =
+    ## Generic Real-to-Complex Tensor plan calculation using FFTW_MEASURE as a default ffwf flag.
+    ##
+    ## Read carefully FFTW documentation about the input / output dimension as FFTW does not calculate redundant conjugate value.
+    case input.rank:
+    of 1:
+      fftwf_plan_dft_r2c_1d(input.shape[0].cint, input.toUnsafeView(), output.toUnsafeView(), flags)
+    of 2:
+      fftwf_plan_dft_r2c_2d(input.shape[0].cint, input.shape[1].cint, input.toUnsafeView(), output.toUnsafeView(), flags)
+    of 3:
+      fftwf_plan_dft_r2c_3d(input.shape[0].cint, input.shape[1].cint, input.shape[2].cint, input.toUnsafeView(), output.toUnsafeView(), flags)
+    else:
+      let shape: seq[cint] = map(input.shape.toSeq(), proc(x: int): cint = x.cint)
+      fftwf_plan_dft_r2c(input.rank.cint, (shape[0].unsafeaddr), input.toUnsafeView(), output.toUnsafeView(), flags)
+
+
+proc fftwf_plan_dft_c2r*(rank: cint, n: ptr cint, inptr: ptr UncheckedArray[Complex32], outptr: ptr UncheckedArray[
+        cfloat], flags: cuint): fftwf_plan {.cdecl, importc: "fftwf_plan_dft_c2r", dynlib: Fftw3Lib.}
+
+proc fftwf_plan_dft_c2r_1d*(n: cint, inptr: ptr UncheckedArray[Complex32], outptr: ptr UncheckedArray[cfloat],
+        flags: cuint): fftwf_plan {.cdecl, importc: "fftwf_plan_dft_c2r_1d", dynlib: Fftw3Lib.}
+
+proc fftwf_plan_dft_c2r_2d*(n0: cint, n1: cint, inptr: ptr UncheckedArray[Complex32], outptr: ptr UncheckedArray[
+        cfloat], flags: cuint): fftwf_plan {.cdecl, importc: "fftwf_plan_dft_c2r_2d", dynlib: Fftw3Lib.}
+
+proc fftwf_plan_dft_c2r_3d*(n0: cint, n1: cint, n2: cint, inptr: ptr UncheckedArray[Complex32],
+        outptr: ptr UncheckedArray[cfloat], flags: cuint): fftwf_plan {.cdecl, importc: "fftwf_plan_dft_c2r_3d",
+        dynlib: Fftw3Lib.}
+
+proc fftwf_plan_dft_c2r*(input: Tensor[Complex32], output: Tensor[float32], flags: cuint = FFTW_MEASURE): fftwf_plan =
+    ## Generic Complex-to-real Tensor plan calculation using FFTW_MEASURE as a default ffwf flag.
+    case input.rank:
+    of 1:
+      fftwf_plan_dft_c2r_1d(input.shape[0].cint, input.toUnsafeView(), output.toUnsafeView(), flags)
+    of 2:
+      fftwf_plan_dft_c2r_2d(input.shape[0].cint, input.shape[1].cint, input.toUnsafeView(), output.toUnsafeView(), flags)
+    of 3:
+      fftwf_plan_dft_c2r_3d(input.shape[0].cint, input.shape[1].cint, input.shape[2].cint, input.toUnsafeView(), output.toUnsafeView(), flags)
+    else:
+      let shape: seq[cint] = map(input.shape.toSeq(), proc(x: int): cint = x.cint)
+      fftwf_plan_dft_c2r(input.rank.cint, (shape[0].unsafeaddr), input.toUnsafeView(), output.toUnsafeView(), flags)
+
+proc fftwf_plan_r2r*(rank: cint, n: ptr cint, inptr: ptr UncheckedArray[cfloat], outptr: ptr UncheckedArray[cfloat],
+        kind: ptr fftwf_r2r_kind, flags: cuint): fftwf_plan {.cdecl, importc: "fftwf_plan_r2r", dynlib: Fftw3Lib.}
+
+proc fftwf_plan_r2r_1d*(n: cint, inptr: ptr UncheckedArray[cfloat], outptr: ptr UncheckedArray[cfloat],
+        kind: fftwf_r2r_kind, flags: cuint): fftwf_plan {.cdecl, importc: "fftwf_plan_r2r_1d", dynlib: Fftw3Lib.}
+
+proc fftwf_plan_r2r_2d*(n0: cint, n1: cint, inptr: ptr UncheckedArray[cfloat], outptr: ptr UncheckedArray[cfloat],
+        kind0: fftwf_r2r_kind, kind1: fftwf_r2r_kind, flags: cuint): fftwf_plan {.cdecl, importc: "fftwf_plan_r2r_2d",
+        dynlib: Fftw3Lib.}
+
+proc fftwf_plan_r2r_3d*(n0: cint, n1: cint, n2: cint, inptr: ptr UncheckedArray[cfloat], outptr: ptr UncheckedArray[
+        cfloat], kind0: fftwf_r2r_kind, kind1: fftwf_r2r_kind, kind2: fftwf_r2r_kind, flags: cuint): fftwf_plan {.cdecl,
+        importc: "fftwf_plan_r2r_3d", dynlib: Fftw3Lib.}
+
+proc fftwf_plan_r2r*(input: Tensor[float32], output: Tensor[float32], kinds: seq[fftwf_r2r_kind],
+        flags: cuint = FFTW_MEASURE): fftwf_plan =
+    ## Generic real-to-real Tensor plan calculation using FFTW_MEASURE as a default ffwf flag.
+    case input.rank:
+    of 1:
+      fftwf_plan_r2r_1d(input.shape[0].cint, input.toUnsafeView(), output.toUnsafeView(), kinds[0], flags)
+    of 2:
+      fftwf_plan_r2r_2d(input.shape[0].cint, input.shape[1].cint, input.toUnsafeView(), output.toUnsafeView(), kinds[0], kinds[1], flags)
+    of 3:
+      fftwf_plan_r2r_3d(input.shape[0].cint, input.shape[1].cint, input.shape[2].cint, input.toUnsafeView(), output.toUnsafeView(), kinds[0], kinds[1], kinds[2], flags)
+    else:
+      let shape: seq[cint] = map(input.shape.toSeq, proc(x: int): cint = x.cint)
+      fftwf_plan_r2r(input.rank.cint, shape[0].unsafeaddr, input.toUnsafeView(), output.toUnsafeView(), kinds[0].unsafeaddr, flags)
+
+# FFTW Plan Many API
+proc fftwf_plan_many_dft*(rank: cint, n: ptr cint, howmany: cint, inptr: ptr UncheckedArray[Complex32],
+        inembed: ptr cint, istride: cint, idist: cint, outptr: ptr UncheckedArray[Complex32], onembed: ptr cint,
+        ostride: cint, odist: cint, sign: cint, flags: cuint): fftwf_plan {.cdecl, importc: "fftwf_plan_many_dft",
+        dynlib: Fftw3Lib.}
+    ## Plan mutliple multidimensionnal complex DFTs and extend ``fftwf_plan_dft`` to compute howmany transforms, each having rank rank and size n.
+    ##
+    ## ``howmany`` is the (nonnegative) number of transforms to compute. The resulting plan computes howmany transforms, where the input of the k-th transform is at location in+k*idist (in C pointer arithmetic), and its output is at location out+k*odist.
+    ##
+    ## Plans obtained in this way can often be faster than calling FFTW multiple times for the individual transforms. The basic fftwf_plan_dft interface corresponds to howmany=1 (in which case the dist parameters are ignored).
+
+proc fftwf_plan_many_dft_c2r*(rank: cint, n: ptr cint, howmany: cint,
+                             inptr: ptr UncheckedArray[Complex32], inembed: ptr cint,
+                             istride: cint, idist: cint, outptr: ptr UncheckedArray[cfloat],
+                             onembed: ptr cint, ostride: cint, odist: cint,
+                             flags: cuint): fftwf_plan {.cdecl,
+    importc: "fftwf_plan_many_dft_c2r", dynlib: Fftw3Lib.}
+
+proc fftwf_plan_many_dft_r2c*(rank: cint, n: ptr cint, howmany: cint,
+                             inptr: ptr UncheckedArray[cfloat], inembed: ptr cint,
+                             istride: cint, idist: cint,
+                             outptr: ptr UncheckedArray[Complex32], onembed: ptr cint,
+                             ostride: cint, odist: cint, flags: cuint): fftwf_plan {.
+    cdecl, importc: "fftwf_plan_many_dft_r2c", dynlib: Fftw3Lib.}
+
+proc fftwf_plan_many_r2r*(rank: cint, n: ptr cint, howmany: cint,
+                         inptr: ptr UncheckedArray[cfloat], inembed: ptr cint, istride: cint,
+                         idist: cint, outptr: ptr UncheckedArray[cfloat], onembed: ptr cint,
+                         ostride: cint, odist: cint, kind: ptr fftwf_r2r_kind,
+                         flags: cuint): fftwf_plan {.cdecl,
+    importc: "fftwf_plan_many_r2r", dynlib: Fftw3Lib.}
+
+proc fftwf_set_timelimit*(t: cfloat) {.cdecl, importc: "fftwf_set_timelimit", dynlib: Fftw3Lib.}
+  ## Set timelimit to FFT
+
+# FFTW Utility & Cleanup API
+proc fftwf_destroy_plan*(p: fftwf_plan) {.cdecl, importc: "fftwf_destroy_plan", dynlib: Fftw3Lib.}
+  ## Destroy a plan
+
+proc fftwf_cleanup*() {.cdecl, importc: "fftwf_cleanup", dynlib: Fftw3Lib.}
+  ## All existing plans become undefined, and you should not attempt to execute them nor to destroy them. You can however create and execute/destroy new plans, in which case FFTW starts accumulating wisdom information again.
+
+when compileOption("threads"):
+  proc fftwf_init_threads*() {.cdecl, importc: "fftwf_init_threads", dynlib: Fftw3Lib.}
+    ## Initialize once before using thread-ed plan
+    ## Needs ``--threads:on`` to be enabled
+  proc fftwf_plan_with_nthreads*(nthreads: cint) {.cdecl, importc: "fftwf_plan_with_nthreads", dynlib: Fftw3Lib.}
+    ## Set the number of threads to use
+    ## Needs ``--threads:on`` to be enabled
+  proc fftwf_cleanup_threads*() {.cdecl, importc: "fftwf_cleanup_threads", dynlib: Fftw3Lib.}
+    ## Additional clean-up when threads are used
+    ## Needs ``--threads:on`` to be enabled
+

--- a/fftw3f/fftshift.nim
+++ b/fftw3f/fftshift.nim
@@ -1,0 +1,132 @@
+import arraymancer
+import arraymancer/tensor/private/p_accessors
+import sequtils
+import sugar
+
+proc get2DCoord(index: int, Nx, Ny: int): array[2, int] {.inline.} =
+  var index = index
+  result[0] = index div Ny
+  index = index - result[0]*Ny
+  result[1] = index
+
+proc get3DCoord(index: int, Nx, Ny, Nz: int): array[3, int] {.inline.} =
+  var index = index
+  result[0] = index div (Nz*Ny)
+  index = index - result[0]*Nz*Ny
+  result[1] = index div Nz
+  index = index - result[1]*Nz
+  result[2] = index
+
+proc get2DCoord[T](index: int, t: Tensor[T]): array[2, int] {.inline.} =
+  doAssert t.rank == 2
+  let Nx = t.shape[0]
+  let Ny = t.shape[1]
+  result = get2DCoord(index, Nx, Ny)
+
+proc get3DCoord[T](index: int, t: Tensor[T]): array[3, int] {.inline.} =
+  doAssert t.rank == 3
+  let Nx = t.shape[0]
+  let Ny = t.shape[1]
+  let Nz = t.shape[2]
+  result = get3DCoord(index, Nx, Ny, Nz)
+
+proc I(coord: openArray[int]): int {.inline.} =
+  return coord[0]
+
+proc J(coord: openArray[int]): int {.inline.} =
+  return coord[1]
+
+proc K(coord: openArray[int]): int {.inline.} =
+  return coord[2]
+
+# FFT Shift
+proc circshift_impl[T](t: Tensor[T], xshift: int, yshift: int, zshift: int): Tensor[T] =
+  assert(t.rank == 3)
+  let
+    X = t.shape[0]
+    Y = t.shape[1]
+    Z = t.shape[2]
+  result = newTensor[T](X, Y, Z)
+  for idx in 0||(result.size-1):
+    let
+      coord = idx.get3DCoord(result)
+      ii = (coord.I + xshift) mod X
+      jj = (coord.J + yshift) mod Y
+      kk = (coord.K + zshift) mod Z
+    result[ii, jj, kk] = t[coord.I, coord.J, coord.K]
+
+proc circshift_impl[T](t: Tensor[T], xshift: int, yshift: int): Tensor[T] =
+  assert(t.rank == 2)
+  let
+    X = t.shape[0]
+    Y = t.shape[1]
+  result = newTensor[T](X, Y)
+  for idx in 0||(result.size-1):
+    let
+      coord = idx.get2DCoord(result)
+      ii = (coord.I + xshift) mod X
+      jj = (coord.J + yshift) mod Y
+    result[ii, jj] = t[coord.I, coord.J]
+
+proc circshift_impl[T](t: Tensor[T], xshift: int): Tensor[T] =
+  assert(t.rank == 1)
+  var X = t.shape[0]
+
+  result = newTensor[T](t.shape.toSeq)
+  for i in 0||(X-1):
+    var ii = (i + xshift) mod X
+    result[ii] = t[i]
+
+# TODO : Generic implementation in parallel
+proc circshift_impl[T](t: Tensor[T], shift: seq[int]): Tensor[T] =
+  let shape = t.shape.toSeq
+  result = newTensor[T](t.shape.toSeq)
+  for coord, values in t:
+    var newcoord: seq[int] = newSeq[int](t.rank)
+    for i in 0..<t.rank:
+      newcoord[i] = (coord[i]+shift[i]) mod shape[i]
+    result.atIndexMut(newcoord, values)
+
+proc circshift*[T](t: Tensor[T], shift: seq[int]): Tensor[T] =
+  ## Generic Circshift
+  # assert(t.rank == shift.len)
+  case t.rank
+  of 1:
+    result = circshift_impl(t, shift[0])
+  of 2:
+    result = circshift_impl(t, shift[0], shift[1])
+  of 3:
+    result = circshift_impl(t, shift[0], shift[1], shift[2])
+  else:
+    result = circshift_impl(t, shift)
+
+proc fftshift*[T](t: Tensor[T]): Tensor[T] =
+  ## Common fftshift function.
+  ## Use Nim's openMP operator (`||`) for rank <= 3
+  ##
+  ## For parallel implementation based on Weave, use ``fftshift_parallel`` in ``fftw3/fftshift_weave``
+  runnableExamples:
+    import arraymancer
+    let input_tensor = randomTensor[float64](10, 10, 10, 10.0)
+    # output_tensor is the fftshift of input_tensor
+    var output_tensor = fftshift(input_tensor)
+
+  # Calculate fftshift using circshift
+  var shifts = t.shape.toSeq.map(x => (x) div 2)
+  result = circshift(t, shifts)
+
+proc ifftshift*[T](t: Tensor[T]): Tensor[T] =
+  ## Common ifftshift function.
+  ## Use Nim's openMP operator (`||`) for rank <= 3.
+  ##
+  ## For parallel implementation based on Weave, use ``ifftshift_parallel`` in ``fftw3/fftshift_weave``
+  runnableExamples:
+    import arraymancer
+    let input_tensor = randomTensor[float64](10, 10, 10, 10.0)
+    # output_tensor is the fftshift of input_tensor
+    var output_tensor = ifftshift(input_tensor)
+
+  # Calculate inverse fftshift using circshift
+  var shifts = t.shape.toSeq.map(x => (x+1) div 2)
+  result = circshift(t, shifts)
+

--- a/fftw3f/fftshift_weave.nim
+++ b/fftw3f/fftshift_weave.nim
@@ -1,0 +1,157 @@
+import typetraits
+import sequtils
+import sugar
+
+import arraymancer
+import weave
+###################################
+## Tools
+###################################
+func getIndex*(offset: int, strides, shape: openArray[int], idx: varargs[int]): int {.noSideEffect, inline.} =
+  result = offset
+  for i in 0..<idx.len:
+    result += strides[i]*idx[i]
+
+func getShiftedIndex*(offset: int, strides, shape: openArray[int], shifts: openArray[int], idx: varargs[int]): int {.noSideEffect, inline.} =
+  result = offset
+  for i in 0..<idx.len:
+    let newidx = (idx[i] + shifts[i]) mod shape[i]
+    result += strides[i]*newidx
+
+###################################
+## Circshift
+###################################
+proc circshift1_weave[T](inBuf, outBuf: ptr UncheckedArray[T], offset: int, strides, shape: seq[int], shifts: seq[int]) =
+  parallelFor i in 0..<shape[0]:
+    captures: {inBuf, outBuf, offset, strides, shape, shifts}
+
+    outBuf[getShiftedIndex(offset, strides, shape, shifts, i)] = inBuf[getIndex(offset, strides, shape, i)]
+
+proc circshift2_weave[T](inBuf, outBuf: ptr UncheckedArray[T], offset: int, strides, shape: seq[int], shifts: seq[int]) =
+  parallelFor i in 0..<shape[0]:
+    captures: {inBuf, outBuf, offset, strides, shape, shifts}
+
+    parallelFor j in 0..<shape[1]:
+      captures: {inBuf, outBuf, offset, strides, shape, shifts, i}
+
+      outBuf[getShiftedIndex(offset, strides, shape, shifts, i, j)] = inBuf[getIndex(offset, strides, shape, i, j)]
+
+proc circshift3_weave[T](inBuf, outBuf: ptr UncheckedArray[T], offset: int, strides, shape: seq[int], shifts: seq[int]) =
+  parallelFor i in 0..<shape[0]:
+    captures: {inBuf, outBuf, offset, strides, shape, shifts}
+
+    parallelFor j in 0..<shape[1]:
+      captures: {inBuf, outBuf, offset, strides, shape, shifts, i}
+
+      parallelFor k in 0..<shape[2]:
+        captures: {inBuf, outBuf, offset, strides, shape, shifts, i, j}
+
+        outBuf[getShiftedIndex(offset, strides, shape, shifts, i, j, k)] = inBuf[getIndex(offset, strides, shape, i, j, k)]
+
+proc circshift4_weave[T](inBuf, outBuf: ptr UncheckedArray[T], offset: int, strides, shape: seq[int], shifts: seq[int]) =
+  parallelFor i in 0..<shape[0]:
+    captures: {inBuf, outBuf, offset, strides, shape, shifts}
+
+    parallelFor j in 0..<shape[1]:
+      captures: {inBuf, outBuf, offset, strides, shape, shifts, i}
+
+      parallelFor k in 0..<shape[2]:
+        captures: {inBuf, outBuf, offset, strides ,shape, shifts, i, j}
+
+        parallelFor l in 0..<shape[3]:
+          captures: {inBuf, outBuf, offset, strides, shape, shifts, i, j, k}
+
+          outBuf[getShiftedIndex(offset, strides, shape, shifts, i, j, k, l)] = inBuf[getIndex(offset, strides, shape, i, j, k, l)]
+
+proc circshift5_weave[T](inBuf, outBuf: ptr UncheckedArray[T], offset: int, strides, shape: seq[int], shifts: seq[int]) =
+  parallelFor i in 0..<shape[0]:
+    captures: {inBuf, outBuf, offset, strides, shape, shifts}
+
+    parallelFor j in 0..<shape[1]:
+      captures: {inBuf, outBuf, offset, strides, shape, shifts, i}
+
+      parallelFor k in 0..<shape[2]:
+        captures: {inBuf, outBuf, offset, strides, shape, shifts, i, j}
+
+        parallelFor l in 0..<shape[3]:
+          captures: {inBuf, outBuf, offset, strides, shape, shifts, i, j, k}
+
+          parallelFor m in 0..<shape[4]:
+            captures: {inBuf, outBuf, offset, strides, shape, shifts, i, j, k, l}
+
+            outBuf[getShiftedIndex(offset, strides, shape, shifts, i, j, k, l, m)] = inBuf[getIndex(offset, strides, shape, i, j, k, l, m)]
+
+proc circshift6_weave[T](inBuf, outBuf: ptr UncheckedArray[T], offset: int, strides, shape: seq[int], shifts: seq[int]) =
+  parallelFor i in 0..<shape[0]:
+    captures: {inBuf, outBuf, offset, strides, shape, shifts}
+
+    parallelFor j in 0..<shape[1]:
+      captures: {inBuf, outBuf, offset, strides, shape, shifts, i}
+
+      parallelFor k in 0..<shape[2]:
+        captures: {inBuf, outBuf, offset, strides, shape, shifts, i, j}
+
+        parallelFor l in 0..<shape[3]:
+          captures: {inBuf, outBuf, offset, strides, shape, shifts, i, j, k}
+
+          parallelFor m in 0..<shape[4]:
+            captures: {inBuf, outBuf, offset, strides, shape, shifts, i, j, k, l}
+
+            parallelFor n in 0..<shape[5]:
+              captures: {inBuf, outBuf, offset, strides, shape, shifts, i, j, k, l, m}
+
+              outBuf[getShiftedIndex(offset, strides, shape, shifts, i, j, k, l, m, n)] = inBuf[getIndex(offset, strides, shape, i, j, k, l, m, n)]
+
+proc circshift_weave[T](inBuf, outBuf: ptr UncheckedArray[T], offset: int, strides, shape: seq[int], shifts: seq[int]) =
+
+  when not defined(WeaveCustomInit):
+    init(Weave)
+
+  case shifts.len
+  of 1:
+    circshift1_weave(inBuf, outBuf, offset, strides, shape, shifts)
+  of 2:
+    circshift2_weave(inBuf, outBuf, offset, strides, shape, shifts)
+  of 3:
+    circshift3_weave(inBuf, outBuf, offset, strides, shape, shifts)
+  of 4:
+    circshift4_weave(inBuf, outBuf, offset, strides, shape, shifts)
+  of 5:
+    circshift5_weave(inBuf, outBuf, offset, strides, shape, shifts)
+  of 6:
+    circshift6_weave(inBuf, outBuf, offset, strides, shape, shifts)
+  else:
+    raise newException(ValueError, "Can only supports tensor of rank 6")
+
+  when not defined(WeaveCustomInit):
+    exit(Weave)
+
+proc fftshift_parallel*[T](t: Tensor[T]): Tensor[T] =
+  ## fftshift implementation based on Weave.
+  ## Use ``-d:WeaveCustomInit`` to indicate that weave is initialized (and finalized) manually outside this scope.
+  let
+    strides = t.strides.toSeq
+    shape = t.shape.toSeq
+    shifts = t.shape.toSeq.map(x => x div 2)
+  # Alloc Tensor
+  result = newTensor[T](shape)
+  let
+    ptrIn = t.unsafe_raw_offset().distinctBase()
+    ptrOut = result.unsafe_raw_offset().distinctBase()
+
+  circshift_weave[T](ptrIn, ptrOut, t.offset, strides, shape, shifts)
+
+proc ifftshift_parallel*[T](t: Tensor[T]): Tensor[T] =
+  ## ifftshift implementation based on Weave.
+  ## Use ``-d:WeaveCustomInit`` flag to indicate that weave is initialized (and finalized) manually outside this scope.
+  let
+    strides = t.strides.toSeq
+    shape = t.shape.toSeq
+    shifts = t.shape.toSeq.map(x => (x+1) div 2)
+  # Alloc Tensor
+  result = newTensor[T](shape)
+  let
+    ptrIn = t.unsafe_raw_offset().distinctBase()
+    ptrOut = result.unsafe_raw_offset().distinctBase()
+
+  circshift_weave[T](ptrIn, ptrOut, t.offset, strides, shape, shifts)

--- a/fftw3f/guru.nim
+++ b/fftw3f/guru.nim
@@ -1,0 +1,95 @@
+import libutils
+import complex
+
+## FFTW Guru API for experts who knows what they're doing.
+
+# Split Array API
+proc fftwf_execute_split_dft*(p: fftwf_plan, ri: ptr cdouble, ii: ptr cdouble, ro: ptr cdouble, io: ptr cdouble) {.cdecl,
+        importc: "fftwf_execute_split_dft", dynlib: Fftw3Lib.}
+
+proc fftwf_execute_split_dft_r2c*(p: fftwf_plan, inptr: ptr cdouble, ro: ptr cdouble, io: ptr cdouble) {.cdecl,
+        importc: "fftwf_execute_split_dft_r2c", dynlib: Fftw3Lib.}
+
+proc fftwf_execute_split_dft_c2r*(p: fftwf_plan, ri: ptr cdouble, ii: ptr cdouble, outptr: ptr cdouble) {.cdecl,
+        importc: "fftwf_execute_split_dft_c2r", dynlib: Fftw3Lib.}
+
+
+# FFTW "Guru" API
+proc fftwf_plan_guru_dft*(rank: cint, dims: ptr fftwf_iodim, howmany_rank: cint,
+                         howmany_dims: ptr fftwf_iodim, inptr: ptr Complex64,
+                         outptr: ptr Complex64, sign: cint, flags: cuint): fftwf_plan {.
+    cdecl, importc: "fftwf_plan_guru_dft", dynlib: Fftw3Lib.}
+proc fftwf_plan_guru_split_dft*(rank: cint, dims: ptr fftwf_iodim,
+                               howmany_rank: cint, howmany_dims: ptr fftwf_iodim,
+                               ri: ptr cdouble, ii: ptr cdouble,
+                               ro: ptr cdouble, io: ptr cdouble, flags: cuint): fftwf_plan {.
+    cdecl, importc: "fftwf_plan_guru_split_dft", dynlib: Fftw3Lib.}
+proc fftwf_plan_guru64_dft*(rank: cint, dims: ptr fftwf_iodim64,
+                           howmany_rank: cint, howmany_dims: ptr fftwf_iodim64,
+                           inptr: ptr Complex64, outptr: ptr Complex64,
+                           sign: cint, flags: cuint): fftwf_plan {.cdecl,
+    importc: "fftwf_plan_guru64_dft", dynlib: Fftw3Lib.}
+proc fftwf_plan_guru64_split_dft*(rank: cint, dims: ptr fftwf_iodim64,
+                                 howmany_rank: cint,
+                                 howmany_dims: ptr fftwf_iodim64,
+                                 ri: ptr cdouble, ii: ptr cdouble,
+                                 ro: ptr cdouble, io: ptr cdouble, flags: cuint): fftwf_plan {.
+    cdecl, importc: "fftwf_plan_guru64_split_dft", dynlib: Fftw3Lib.}
+proc fftwf_plan_guru_dft_r2c*(rank: cint, dims: ptr fftwf_iodim,
+                             howmany_rank: cint, howmany_dims: ptr fftwf_iodim,
+                             inptr: ptr cdouble, outptr: ptr Complex64,
+                             flags: cuint): fftwf_plan {.cdecl,
+    importc: "fftwf_plan_guru_dft_r2c", dynlib: Fftw3Lib.}
+proc fftwf_plan_guru_dft_c2r*(rank: cint, dims: ptr fftwf_iodim,
+                             howmany_rank: cint, howmany_dims: ptr fftwf_iodim,
+                             inptr: ptr Complex64, outptr: ptr cdouble,
+                             flags: cuint): fftwf_plan {.cdecl,
+    importc: "fftwf_plan_guru_dft_c2r", dynlib: Fftw3Lib.}
+proc fftwf_plan_guru_split_dft_r2c*(rank: cint, dims: ptr fftwf_iodim,
+                                   howmany_rank: cint,
+                                   howmany_dims: ptr fftwf_iodim,
+                                   inptr: ptr cdouble, ro: ptr cdouble,
+                                   io: ptr cdouble, flags: cuint): fftwf_plan {.
+    cdecl, importc: "fftwf_plan_guru_split_dft_r2c", dynlib: Fftw3Lib.}
+proc fftwf_plan_guru_split_dft_c2r*(rank: cint, dims: ptr fftwf_iodim,
+                                   howmany_rank: cint,
+                                   howmany_dims: ptr fftwf_iodim,
+                                   ri: ptr cdouble, ii: ptr cdouble,
+                                   outptr: ptr cdouble, flags: cuint): fftwf_plan {.
+    cdecl, importc: "fftwf_plan_guru_split_dft_c2r", dynlib: Fftw3Lib.}
+proc fftwf_plan_guru64_dft_r2c*(rank: cint, dims: ptr fftwf_iodim64,
+                               howmany_rank: cint,
+                               howmany_dims: ptr fftwf_iodim64,
+                               inptr: ptr cdouble, outptr: ptr Complex64,
+                               flags: cuint): fftwf_plan {.cdecl,
+    importc: "fftwf_plan_guru64_dft_r2c", dynlib: Fftw3Lib.}
+proc fftwf_plan_guru64_dft_c2r*(rank: cint, dims: ptr fftwf_iodim64,
+                               howmany_rank: cint,
+                               howmany_dims: ptr fftwf_iodim64,
+                               inptr: ptr Complex64, outptr: ptr cdouble,
+                               flags: cuint): fftwf_plan {.cdecl,
+    importc: "fftwf_plan_guru64_dft_c2r", dynlib: Fftw3Lib.}
+proc fftwf_plan_guru64_split_dft_r2c*(rank: cint, dims: ptr fftwf_iodim64,
+                                     howmany_rank: cint,
+                                     howmany_dims: ptr fftwf_iodim64,
+                                     inptr: ptr cdouble, ro: ptr cdouble,
+                                     io: ptr cdouble, flags: cuint): fftwf_plan {.
+    cdecl, importc: "fftwf_plan_guru64_split_dft_r2c", dynlib: Fftw3Lib.}
+proc fftwf_plan_guru64_split_dft_c2r*(rank: cint, dims: ptr fftwf_iodim64,
+                                     howmany_rank: cint,
+                                     howmany_dims: ptr fftwf_iodim64,
+                                     ri: ptr cdouble, ii: ptr cdouble,
+                                     outptr: ptr cdouble, flags: cuint): fftwf_plan {.
+    cdecl, importc: "fftwf_plan_guru64_split_dft_c2r", dynlib: Fftw3Lib.}
+
+proc fftwf_plan_guru_r2r*(rank: cint, dims: ptr fftwf_iodim, howmany_rank: cint,
+                         howmany_dims: ptr fftwf_iodim, inptr: ptr cdouble,
+                         outptr: ptr cdouble, kind: ptr fftwf_r2r_kind,
+                         flags: cuint): fftwf_plan {.cdecl,
+    importc: "fftwf_plan_guru_r2r", dynlib: Fftw3Lib.}
+proc fftwf_plan_guru64_r2r*(rank: cint, dims: ptr fftwf_iodim64,
+                           howmany_rank: cint, howmany_dims: ptr fftwf_iodim64,
+                           inptr: ptr cdouble, outptr: ptr cdouble,
+                           kind: ptr fftwf_r2r_kind, flags: cuint): fftwf_plan {.
+    cdecl, importc: "fftwf_plan_guru64_r2r", dynlib: Fftw3Lib.}
+

--- a/fftw3f/libutils.nim
+++ b/fftw3f/libutils.nim
@@ -66,9 +66,9 @@ proc fftwf_cost*(p: fftwf_plan): cdouble {.cdecl, importc: "fftwf_cost", dynlib:
 
 proc fftwf_alignment_of*(p: ptr cdouble): cint {.cdecl, importc: "fftwf_alignment_of", dynlib: Fftw3Lib.}
 
-let fftwf_version* {.importc: "fftwf__version", dynlib: Fftw3Lib.}: cstring
+let fftwf_version* {.importc: "fftwf_version", dynlib: Fftw3Lib.}: cstring
 
-var fftwf_cc* {.importc: "fftwf__cc", dynlib: Fftw3Lib.}: cstring
+var fftwf_cc* {.importc: "fftwf_cc", dynlib: Fftw3Lib.}: cstring
 
-var fftwf_codelet_optim* {.importc: "fftwf__codelet_optim", dynlib: Fftw3Lib.}: cstring
+var fftwf_codelet_optim* {.importc: "fftwf_codelet_optim", dynlib: Fftw3Lib.}: cstring
 

--- a/fftw3f/libutils.nim
+++ b/fftw3f/libutils.nim
@@ -1,0 +1,74 @@
+import complex
+import os
+
+## Some utility types and functions not directly used to calculate FFT
+when defined(windows):
+  const Fftw3LibName = "libfftw3f-3.dll"
+elif defined(macosx):
+  const Fftw3LibName* = "libfftw3f(|.0).dylib"
+else:
+  const Fftw3LibName* = "libfftw3f.so.(|3|3.6.9)"
+
+when defined(localFftw3):
+  const Fftw3LibPath = currentSourcePath().parentDir().parentDir() / "third_party" / "lib"
+  const Fftw3Lib* = Fftw3LibPath / Fftw3LibName
+else:
+  const Fftw3Lib* = Fftw3LibName
+# static:
+#   debugEcho "nim-ffwf3> Using dynamic library: ", Fftw3Lib
+
+proc getFftw3Lib*() : string {.compiletime.}=
+  return Fftw3Lib
+
+type
+  fftwfr2r_kind* = enum
+    FFTW_R2HC = 0, FFTW_HC2R = 1, FFTW_DHT = 2, FFTW_REDFT00 = 3, FFTW_REDFT01 = 4, FFTW_REDFT10 = 5, FFTW_REDFT11 = 6, FFTW_RODFT00 = 7, FFTW_RODFT01 = 8, FFTW_RODFT10 = 9, FFTW_RODFT11 = 10
+
+  fftwfiodim* {.pure.} = object
+    n*: cint
+    `is`*: cint
+    os*: cint
+
+  ptrdiff_t* = clong
+  wchar_t* = cint
+  fftwfiodim64* {.pure.} = object
+    n*: ptrdiff_t
+    `is`*: ptrdiff_t
+    os*: ptrdiff_t
+
+  fftwfwrite_char_func* = proc (c: char, a3: pointer) {.cdecl.}
+  fftwfread_char_func* = proc (a2: pointer): cint {.cdecl.}
+  # Deprecated -> Use complex
+  fftwfcomplex = Complex64
+  fftwfplan* = pointer
+
+
+proc fftwffprint_plan*(p: fftwfplan, output_file: ptr FILE) {.cdecl, importc: "fftwffprint_plan", dynlib: Fftw3Lib.}
+
+proc fftwfprint_plan*(p: fftwfplan) {.cdecl, importc: "fftwfprint_plan", dynlib: Fftw3Lib.}
+
+proc fftwfsprint_plan*(p: fftwfplan): cstring {.cdecl, importc: "fftwfsprint_plan", dynlib: Fftw3Lib.}
+
+proc fftwfmalloc*(n: csize_t): pointer {.cdecl, importc: "fftwfmalloc", dynlib: Fftw3Lib.}
+
+proc fftwfalloc_real*(n: csize_t): ptr cdouble {.cdecl, importc: "fftwfalloc_real", dynlib: Fftw3Lib.}
+
+proc fftwfalloc_complex*(n: csize_t): ptr fftwfcomplex {.cdecl, importc: "fftwfalloc_complex", dynlib: Fftw3Lib.}
+
+proc fftwffree*(p: pointer) {.cdecl, importc: "fftwffree", dynlib: Fftw3Lib.}
+
+proc fftwfflops*(p: fftwfplan, add: ptr cdouble, mul: ptr cdouble, fmas: ptr cdouble) {.cdecl, importc: "fftwfflops",
+        dynlib: Fftw3Lib.}
+
+proc fftwfestimate_cost*(p: fftwfplan): cdouble {.cdecl, importc: "fftwfestimate_cost", dynlib: Fftw3Lib.}
+
+proc fftwfcost*(p: fftwfplan): cdouble {.cdecl, importc: "fftwfcost", dynlib: Fftw3Lib.}
+
+proc fftwfalignment_of*(p: ptr cdouble): cint {.cdecl, importc: "fftwfalignment_of", dynlib: Fftw3Lib.}
+
+let fftwf_version* {.importc: "fftwf_version", dynlib: Fftw3Lib.}: cstring
+
+var fftwf_cc* {.importc: "fftwf_cc", dynlib: Fftw3Lib.}: cstring
+
+var fftwf_codelet_optim* {.importc: "fftwf_codelet_optim", dynlib: Fftw3Lib.}: cstring
+

--- a/fftw3f/libutils.nim
+++ b/fftw3f/libutils.nim
@@ -21,54 +21,54 @@ proc getFftw3Lib*() : string {.compiletime.}=
   return Fftw3Lib
 
 type
-  fftwfr2r_kind* = enum
+  fftwf_r2r_kind* = enum
     FFTW_R2HC = 0, FFTW_HC2R = 1, FFTW_DHT = 2, FFTW_REDFT00 = 3, FFTW_REDFT01 = 4, FFTW_REDFT10 = 5, FFTW_REDFT11 = 6, FFTW_RODFT00 = 7, FFTW_RODFT01 = 8, FFTW_RODFT10 = 9, FFTW_RODFT11 = 10
 
-  fftwfiodim* {.pure.} = object
+  fftwf_iodim* {.pure.} = object
     n*: cint
     `is`*: cint
     os*: cint
 
   ptrdiff_t* = clong
   wchar_t* = cint
-  fftwfiodim64* {.pure.} = object
+  fftwf_iodim64* {.pure.} = object
     n*: ptrdiff_t
     `is`*: ptrdiff_t
     os*: ptrdiff_t
 
-  fftwfwrite_char_func* = proc (c: char, a3: pointer) {.cdecl.}
-  fftwfread_char_func* = proc (a2: pointer): cint {.cdecl.}
+  fftwf_write_char_func* = proc (c: char, a3: pointer) {.cdecl.}
+  fftwf_read_char_func* = proc (a2: pointer): cint {.cdecl.}
   # Deprecated -> Use complex
-  fftwfcomplex = Complex64
-  fftwfplan* = pointer
+  fftwf_complex = Complex32
+  fftwf_plan* = pointer
 
 
-proc fftwffprint_plan*(p: fftwfplan, output_file: ptr FILE) {.cdecl, importc: "fftwffprint_plan", dynlib: Fftw3Lib.}
+proc fftwf_fprint_plan*(p: fftwf_plan, output_file: ptr FILE) {.cdecl, importc: "fftwf_fprint_plan", dynlib: Fftw3Lib.}
 
-proc fftwfprint_plan*(p: fftwfplan) {.cdecl, importc: "fftwfprint_plan", dynlib: Fftw3Lib.}
+proc fftwf_print_plan*(p: fftwf_plan) {.cdecl, importc: "fftwf_print_plan", dynlib: Fftw3Lib.}
 
-proc fftwfsprint_plan*(p: fftwfplan): cstring {.cdecl, importc: "fftwfsprint_plan", dynlib: Fftw3Lib.}
+proc fftwf_sprint_plan*(p: fftwf_plan): cstring {.cdecl, importc: "fftwf_sprint_plan", dynlib: Fftw3Lib.}
 
-proc fftwfmalloc*(n: csize_t): pointer {.cdecl, importc: "fftwfmalloc", dynlib: Fftw3Lib.}
+proc fftwf_malloc*(n: csize_t): pointer {.cdecl, importc: "fftwf_malloc", dynlib: Fftw3Lib.}
 
-proc fftwfalloc_real*(n: csize_t): ptr cdouble {.cdecl, importc: "fftwfalloc_real", dynlib: Fftw3Lib.}
+proc fftwf_alloc_real*(n: csize_t): ptr cdouble {.cdecl, importc: "fftwf_alloc_real", dynlib: Fftw3Lib.}
 
-proc fftwfalloc_complex*(n: csize_t): ptr fftwfcomplex {.cdecl, importc: "fftwfalloc_complex", dynlib: Fftw3Lib.}
+proc fftwf_alloc_complex*(n: csize_t): ptr fftwf_complex {.cdecl, importc: "fftwf_alloc_complex", dynlib: Fftw3Lib.}
 
-proc fftwffree*(p: pointer) {.cdecl, importc: "fftwffree", dynlib: Fftw3Lib.}
+proc fftwf_free*(p: pointer) {.cdecl, importc: "fftwf_free", dynlib: Fftw3Lib.}
 
-proc fftwfflops*(p: fftwfplan, add: ptr cdouble, mul: ptr cdouble, fmas: ptr cdouble) {.cdecl, importc: "fftwfflops",
+proc fftwf_flops*(p: fftwf_plan, add: ptr cdouble, mul: ptr cdouble, fmas: ptr cdouble) {.cdecl, importc: "fftwf_flops",
         dynlib: Fftw3Lib.}
 
-proc fftwfestimate_cost*(p: fftwfplan): cdouble {.cdecl, importc: "fftwfestimate_cost", dynlib: Fftw3Lib.}
+proc fftwf_estimate_cost*(p: fftwf_plan): cdouble {.cdecl, importc: "fftwf_estimate_cost", dynlib: Fftw3Lib.}
 
-proc fftwfcost*(p: fftwfplan): cdouble {.cdecl, importc: "fftwfcost", dynlib: Fftw3Lib.}
+proc fftwf_cost*(p: fftwf_plan): cdouble {.cdecl, importc: "fftwf_cost", dynlib: Fftw3Lib.}
 
-proc fftwfalignment_of*(p: ptr cdouble): cint {.cdecl, importc: "fftwfalignment_of", dynlib: Fftw3Lib.}
+proc fftwf_alignment_of*(p: ptr cdouble): cint {.cdecl, importc: "fftwf_alignment_of", dynlib: Fftw3Lib.}
 
-let fftwf_version* {.importc: "fftwf_version", dynlib: Fftw3Lib.}: cstring
+let fftwf_version* {.importc: "fftwf__version", dynlib: Fftw3Lib.}: cstring
 
-var fftwf_cc* {.importc: "fftwf_cc", dynlib: Fftw3Lib.}: cstring
+var fftwf_cc* {.importc: "fftwf__cc", dynlib: Fftw3Lib.}: cstring
 
-var fftwf_codelet_optim* {.importc: "fftwf_codelet_optim", dynlib: Fftw3Lib.}: cstring
+var fftwf_codelet_optim* {.importc: "fftwf__codelet_optim", dynlib: Fftw3Lib.}: cstring
 

--- a/fftw3f/wisdom.nim
+++ b/fftw3f/wisdom.nim
@@ -1,0 +1,23 @@
+import libutils
+
+## FFTW Wisdom API for saving and restoring ``fftwf_plan`` from disk.
+## See `Wisdom documentation <http://www.ffwf.org/ffwf3_doc/Wisdom.html>`_ for more information.
+
+proc fftwf_forget_wisdom*() {.cdecl, importc: "fftwf_forget_wisdom", dynlib: Fftw3Lib.}
+proc fftwf_export_wisdom_to_filename*(filename: cstring): cint {.cdecl, importc: "fftwf_export_wisdom_to_filename",
+        dynlib: Fftw3Lib.}
+proc fftwf_export_wisdom_to_file*(output_file: ptr FILE) {.cdecl, importc: "fftwf_export_wisdom_to_file",
+        dynlib: Fftw3Lib.}
+proc fftwf_export_wisdom_to_string*(): cstring {.cdecl, importc: "fftwf_export_wisdom_to_string", dynlib: Fftw3Lib.}
+proc fftwf_export_wisdom*(write_char: fftwf_write_char_func, data: pointer) {.cdecl, importc: "fftwf_export_wisdom",
+        dynlib: Fftw3Lib.}
+proc fftwf_import_system_wisdom*(): cint {.cdecl, importc: "fftwf_import_system_wisdom", dynlib: Fftw3Lib.}
+proc fftwf_import_wisdom_from_filename*(filename: cstring): cint {.cdecl, importc: "fftwf_import_wisdom_from_filename",
+        dynlib: Fftw3Lib.}
+proc fftwf_import_wisdom_from_file*(input_file: ptr FILE): cint {.cdecl, importc: "fftwf_import_wisdom_from_file",
+        dynlib: Fftw3Lib.}
+proc fftwf_import_wisdom_from_string*(input_string: cstring): cint {.cdecl,
+    importc: "fftwf_import_wisdom_from_string", dynlib: Fftw3Lib.}
+proc fftwf_import_wisdom*(read_char: fftwf_read_char_func, data: pointer): cint {.cdecl, importc: "fftwf_import_wisdom",
+    dynlib: Fftw3Lib.}
+


### PR DESCRIPTION
Hello! Thank you for making nimfftw3!!! <3

I noticed some additional steps were required to get the single-precision float version to work.

- rename all procedure and variable prefixes from `fftw_` to `fftwf_`
- change all instaces of `cdouble` to `cfloat`, `float64` to `float32`, and `Complex64` to `Complex32`

I considered using macros to do the prefixes and generics for the types, but since the FFTW api won't change, I believe the most straight forward way to achieve single precision float support is to make a copy of your library in `fftw3f.nim` and `fftw3f` and text-replace. Usage then mirrors the original FFTW: import what you want and use what you want. You can even have both in the same project.

Let me know if you would are interested in merging this, I would be happy to adapt the readme as well.

Thanks again! Carlo
